### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/python/tests/test_module.py
+++ b/python/tests/test_module.py
@@ -9,9 +9,11 @@ TEST_DIR = os.path.join(os.path.dirname(__file__))
 class TestECHO(unittest.TestCase):
     def test_parse_flat_payload(self):
         # read data/test_flat.json into payload dict
-        payload = json.load(open(TEST_DIR + "/data/test_flat_basic.json", "r"))
-        flat_ECHO(**payload)
+        with open(TEST_DIR + "/data/test_flat_basic.json", "r") as f:
+            payload = json.load(f)
+            flat_ECHO(**payload)
 
-    def test_parse_nested_payload(self):    
-        payload = json.load(open(TEST_DIR + "/data/test_nested_basic.json", "r"))
-        nested_ECHO(**payload)
+    def test_parse_nested_payload(self): 
+        with open(TEST_DIR + "/data/test_nested_basic.json", "r") as f:
+            payload = json.load(f)
+            nested_ECHO(**payload)


### PR DESCRIPTION
This pull request fixes a file-handling issue in the tests. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python’s garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.